### PR TITLE
Add GitHub tab view controls

### DIFF
--- a/GithubVSAutomationIDs/AutomationIDs.Designer.cs
+++ b/GithubVSAutomationIDs/AutomationIDs.Designer.cs
@@ -97,6 +97,24 @@ namespace GithubVSAutomationIDs {
         }
         
         /// <summary>
+        ///   Looks up a localized string similar to GitHubLoggedOutCreateAnAccountHyperlink.
+        /// </summary>
+        public static string GitHubLoggedOutCreateAnAccountHyperlink {
+            get {
+                return ResourceManager.GetString("GitHubLoggedOutCreateAnAccountHyperlink", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to GitHubLoggedOutSignInHyperlink.
+        /// </summary>
+        public static string GitHubLoggedOutSignInHyperlink {
+            get {
+                return ResourceManager.GetString("GitHubLoggedOutSignInHyperlink", resourceCulture);
+            }
+        }
+        
+        /// <summary>
         ///   Looks up a localized string similar to GitHubTabItem.
         /// </summary>
         public static string GitHubTabItem {
@@ -147,6 +165,24 @@ namespace GithubVSAutomationIDs {
         public static string GitHubToolBarRefreshImage {
             get {
                 return ResourceManager.GetString("GitHubToolBarRefreshImage", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to LoggedOutViewCustom.
+        /// </summary>
+        public static string LoggedOutViewCustom {
+            get {
+                return ResourceManager.GetString("LoggedOutViewCustom", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to PowerfulCollaborationTextBlock.
+        /// </summary>
+        public static string PowerfulCollaborationTextBlock {
+            get {
+                return ResourceManager.GetString("PowerfulCollaborationTextBlock", resourceCulture);
             }
         }
         
@@ -264,6 +300,15 @@ namespace GithubVSAutomationIDs {
         public static string SignInModal {
             get {
                 return ResourceManager.GetString("SignInModal", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to SignInToGitHubTextBlock.
+        /// </summary>
+        public static string SignInToGitHubTextBlock {
+            get {
+                return ResourceManager.GetString("SignInToGitHubTextBlock", resourceCulture);
             }
         }
         

--- a/GithubVSAutomationIDs/AutomationIDs.resx
+++ b/GithubVSAutomationIDs/AutomationIDs.resx
@@ -189,4 +189,19 @@
   <data name="GitHubToolBarRefreshImage" xml:space="preserve">
     <value>GitHubToolBarRefreshImage</value>
   </data>
+  <data name="GitHubLoggedOutCreateAnAccountHyperlink" xml:space="preserve">
+    <value>GitHubLoggedOutCreateAnAccountHyperlink</value>
+  </data>
+  <data name="GitHubLoggedOutSignInHyperlink" xml:space="preserve">
+    <value>GitHubLoggedOutSignInHyperlink</value>
+  </data>
+  <data name="LoggedOutViewCustom" xml:space="preserve">
+    <value>LoggedOutViewCustom</value>
+  </data>
+  <data name="PowerfulCollaborationTextBlock" xml:space="preserve">
+    <value>PowerfulCollaborationTextBlock</value>
+  </data>
+  <data name="SignInToGitHubTextBlock" xml:space="preserve">
+    <value>SignInToGitHubTextBlock</value>
+  </data>
 </root>


### PR DESCRIPTION
These are IDs for the controls that reside in the docked GitHub tab view.