### PR TITLE
Split the IDs and unit test projects

### DIFF
--- a/GitHubVSTestAutomationIDs.sln
+++ b/GitHubVSTestAutomationIDs.sln
@@ -3,7 +3,9 @@ Microsoft Visual Studio Solution File, Format Version 12.00
 # Visual Studio 14
 VisualStudioVersion = 14.0.25420.1
 MinimumVisualStudioVersion = 10.0.40219.1
-Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "GithubVSTestAutomationIDs", "GithubVSAutomationIDs\GithubVSTestAutomationIDs.csproj", "{665078F4-5875-431D-A2CC-421849B43328}"
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "GithubVSTestAutomationIDs", "GithubVSAutomationIDs\GithubVSTestAutomationIDs.csproj", "{9453C37F-44CF-463D-B563-5C3110CEF5E7}"
+EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "GithubVSTestAutomationIDs.Tests", "GithubVSAutomationIDs.Tests\GithubVSTestAutomationIDs.Tests.csproj", "{665078F4-5875-431D-A2CC-421849B43328}"
 EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
@@ -11,6 +13,10 @@ Global
 		Release|Any CPU = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(ProjectConfigurationPlatforms) = postSolution
+		{9453C37F-44CF-463D-B563-5C3110CEF5E7}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{9453C37F-44CF-463D-B563-5C3110CEF5E7}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{9453C37F-44CF-463D-B563-5C3110CEF5E7}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{9453C37F-44CF-463D-B563-5C3110CEF5E7}.Release|Any CPU.Build.0 = Release|Any CPU
 		{665078F4-5875-431D-A2CC-421849B43328}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
 		{665078F4-5875-431D-A2CC-421849B43328}.Debug|Any CPU.Build.0 = Debug|Any CPU
 		{665078F4-5875-431D-A2CC-421849B43328}.Release|Any CPU.ActiveCfg = Release|Any CPU

--- a/GithubVSAutomationIDs.Tests/GithubVSTestAutomationIDs.Tests.csproj
+++ b/GithubVSAutomationIDs.Tests/GithubVSTestAutomationIDs.Tests.csproj
@@ -4,11 +4,11 @@
   <PropertyGroup>
     <Configuration Condition=" '$(Configuration)' == '' ">Debug</Configuration>
     <Platform Condition=" '$(Platform)' == '' ">AnyCPU</Platform>
-    <ProjectGuid>{9453C37F-44CF-463D-B563-5C3110CEF5E7}</ProjectGuid>
+    <ProjectGuid>{665078F4-5875-431D-A2CC-421849B43328}</ProjectGuid>
     <OutputType>Library</OutputType>
     <AppDesignerFolder>Properties</AppDesignerFolder>
     <RootNamespace>GitHub.VisualStudio.TestAutomation</RootNamespace>
-    <AssemblyName>GitHub.VisualStudio.TestAutomation.AutomationIDs</AssemblyName>
+    <AssemblyName>GitHub.VisualStudio.TestAutomation.AutomationIDs.Tests</AssemblyName>
     <TargetFrameworkVersion>v4.5.2</TargetFrameworkVersion>
     <FileAlignment>512</FileAlignment>
   </PropertyGroup>
@@ -30,6 +30,7 @@
     <WarningLevel>4</WarningLevel>
   </PropertyGroup>
   <ItemGroup>
+    <Reference Include="Microsoft.VisualStudio.QualityTools.UnitTestFramework, Version=10.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL" />
     <Reference Include="System" />
     <Reference Include="System.Core" />
     <Reference Include="System.Xml.Linq" />
@@ -40,21 +41,17 @@
     <Reference Include="System.Xml" />
   </ItemGroup>
   <ItemGroup>
-    <Compile Include="AutomationIDs.Designer.cs">
-      <AutoGen>True</AutoGen>
-      <DesignTime>True</DesignTime>
-      <DependentUpon>AutomationIDs.resx</DependentUpon>
-    </Compile>
     <Compile Include="Properties\AssemblyInfo.cs" />
-  </ItemGroup>
-  <ItemGroup>
-    <EmbeddedResource Include="AutomationIDs.resx">
-      <Generator>PublicResXFileCodeGenerator</Generator>
-      <LastGenOutput>AutomationIDs.Designer.cs</LastGenOutput>
-    </EmbeddedResource>
+    <Compile Include="ResourceValueTests.cs" />
   </ItemGroup>
   <ItemGroup>
     <Service Include="{82A7F48D-3B50-4B1E-B82E-3ADA8210C358}" />
+  </ItemGroup>
+  <ItemGroup>
+    <ProjectReference Include="..\GithubVSAutomationIDs\GithubVSTestAutomationIDs.csproj">
+      <Project>{9453c37f-44cf-463d-b563-5c3110cef5e7}</Project>
+      <Name>GithubVSTestAutomationIDs</Name>
+    </ProjectReference>
   </ItemGroup>
   <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />
   <!-- To modify your build process, add your task inside one of the targets below and uncomment it.

--- a/GithubVSAutomationIDs.Tests/Properties/AssemblyInfo.cs
+++ b/GithubVSAutomationIDs.Tests/Properties/AssemblyInfo.cs
@@ -1,0 +1,33 @@
+﻿using System.Reflection;
+using System.Runtime.CompilerServices;
+using System.Runtime.InteropServices;
+
+// General Information about an assembly is controlled through the following 
+// set of attributes. Change these attribute values to modify the information
+// associated with an assembly.
+[assembly: AssemblyTitle("GithubVSAutomationIDs.Tests")]
+[assembly: AssemblyDescription("")]
+[assembly: AssemblyConfiguration("")]
+[assembly: AssemblyCompany("")]
+[assembly: AssemblyProduct("GithubVSAutomationIDs.Tests")]
+[assembly: AssemblyCopyright("Copyright ©  2016")]
+[assembly: AssemblyTrademark("")]
+[assembly: AssemblyCulture("")]
+
+// Setting ComVisible to false makes the types in this assembly not visible 
+// to COM components.  If you need to access a type in this assembly from 
+// COM, set the ComVisible attribute to true on that type.
+[assembly: ComVisible(false)]
+
+// Version information for an assembly consists of the following four values:
+//
+//      Major Version
+//      Minor Version 
+//      Build Number
+//      Revision
+//
+// You can specify all the values or you can default the Build and Revision Numbers 
+// by using the '*' as shown below:
+// [assembly: AssemblyVersion("1.0.*")]
+[assembly: AssemblyVersion("1.0.0.0")]
+[assembly: AssemblyFileVersion("1.0.0.0")]

--- a/GithubVSAutomationIDs.Tests/ResourceValueTests.cs
+++ b/GithubVSAutomationIDs.Tests/ResourceValueTests.cs
@@ -1,0 +1,24 @@
+﻿using Microsoft.VisualStudio.TestTools.UnitTesting;
+using System.Collections;
+using System.Globalization;
+using System.Resources;
+
+namespace GitHub.VisualStudio.TestAutomation
+{
+    [TestClass]
+    public class ResourceValueTest
+    {
+        [TestMethod]
+        public void ValueAndNameAreTheSame()
+        {
+            ResourceSet autoIDResourceSet = AutomationIDs.ResourceManager.GetResourceSet(CultureInfo.CurrentUICulture, true, true);
+            foreach (DictionaryEntry entry in autoIDResourceSet)
+            {
+                var key = entry.Key.ToString();
+                var value = entry.Value.ToString();
+
+                Assert.AreEqual(value, key);
+            }
+        }
+    }
+}


### PR DESCRIPTION
We should avoid referencing `Microsoft.VisualStudio.QualityTools.UnitTestFramework` from the assemblies they we deploy.